### PR TITLE
fix(footer): remove react-intl

### DIFF
--- a/jobStreet/Footer/localization/index.js
+++ b/jobStreet/Footer/localization/index.js
@@ -1,8 +1,3 @@
-import { addLocaleData } from 'react-intl';
-import en from 'react-intl/locale-data/en';
-import id from 'react-intl/locale-data/id';
-import vi from 'react-intl/locale-data/vi';
-
 import enMyLocalisation from './en-my';
 import enSgLocalisation from './en-sg';
 import enPhLocalisation from './en-ph';
@@ -10,8 +5,6 @@ import enIdLocalisation from './en-id';
 import enVnLocalisation from './en-vn';
 import idIdLocalisation from './id-id';
 import viVnLocalisation from './vi-vn';
-
-addLocaleData([...en, ...id, ...vi]);
 
 export default {
   'en-my': enMyLocalisation,

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "react-element-to-jsx-string": "^12.0.0",
     "react-helmet": "^3.2.2",
     "react-hot-loader": "^3.0.0-beta.2",
-    "react-intl": "^2.4.0",
     "react-isolated-scroll": "^0.1.0",
     "react-router": "^2.5.2",
     "react-shallow-testutils": "^2.0.0",


### PR DESCRIPTION
## Commit Message For Review

Removes react-intl imports from Jobstreet footer localisation

REASON FOR CHANGE:

The imports are unused, and the style guide currently does not require react-intl as a peer dependency.  This can cause build errors in consuming apps.