### PR TITLE
fix(header): remove position absolute from mobile jobsDB header

### DIFF
--- a/jobsDB/Header/header.less
+++ b/jobsDB/Header/header.less
@@ -36,9 +36,6 @@
     margin: 0 auto;
 }
 .banner {
-    position: absolute;
-    top:0;
-    left:0;
     width: 100%;
     height: 50px;
     display: flex;

--- a/jobsDB/Header/header.less
+++ b/jobsDB/Header/header.less
@@ -45,7 +45,6 @@
     background: #fff;
     border-bottom: 2px solid @dbBlue;
     @media(min-width: 769px) {
-        position: static;
         width: 100%;
         height: 90px;
         justify-content: space-between;


### PR DESCRIPTION
## Commit Message For Review

Removes `position: absolute` from jobsDB header in mobile

REASON FOR CHANGE:

Currently header overlaps content