### PR TITLE
fix(docs): doc site webpack css-in-js

### DIFF
--- a/docs/webpack.static.client.config.js
+++ b/docs/webpack.static.client.config.js
@@ -27,7 +27,7 @@ const config = {
   module: {
     loaders: [
       {
-        test: /\.js$/,
+        test: /(?!\.css)\.js$/,
         loader: 'babel',
         query: babelConfig,
         include: appPaths
@@ -40,6 +40,11 @@ const config = {
           presets: ['es2015']
         },
         include: /node_modules/
+      },
+      {
+        test: /\.css\.js$/,
+        include: appPaths,
+        loader: appCss.extract('style', 'css?modules&localIdentName=[name]__[local]___[hash:base64:5]!postcss!css-in-js!babel?' + JSON.stringify(babelConfig))
       },
       {
         test: /\.less$/,

--- a/docs/webpack.static.render.config.js
+++ b/docs/webpack.static.render.config.js
@@ -29,10 +29,15 @@ const config = {
   module: {
     loaders: [
       {
-        test: /\.js$/,
+        test: /(?!\.css)\.js$/,
         loader: 'babel',
         query: babelConfig,
         include: appPaths
+      },
+      {
+        test: /\.css\.js$/,
+        include: appPaths,
+        loader: 'css/locals?modules&localIdentName=[name]__[local]___[hash:base64:5]!postcss!css-in-js!babel?' + JSON.stringify(babelConfig)
       },
       {
         test: /\.less$/,


### PR DESCRIPTION
REASON FOR CHANGE:

css-in-js was not working in the deployed site owing to being absent from the webpack configs.  While this only affected the doc site and not any consumable components, it was kind of annoying and bad for demos.