### PR TITLE
fix(JobCard): company logo size overflow than the container

### DIFF
--- a/react/JobCard/JobCard.less
+++ b/react/JobCard/JobCard.less
@@ -116,6 +116,7 @@
   display: flex;
   align-items: center;
   align-self: flex-end;
+  overflow: hidden;
 }
 
 .companyLogo {


### PR DESCRIPTION
For the company logo that are not in square size, but having height > width, the border of that container element will be overlay-ed. Applying overflow:hidden to make sure the logo won't overflow.
<img width="972" alt="screen shot 2017-10-20 at 11 53 15 am" src="https://user-images.githubusercontent.com/17079583/31804657-4dcc0dac-b58d-11e7-9c09-1fd9c9922579.png">