### PR TITLE
feat(Dropdown): makes placeholder selectable to clear selection

### DIFF
--- a/react/Dropdown/Dropdown.demo.js
+++ b/react/Dropdown/Dropdown.demo.js
@@ -87,6 +87,13 @@ export default {
             ...props,
             className: classnames(className, styles.rootFocus)
           })
+        },
+        {
+          label: 'Placeholder selectable',
+          transformProps: ({ className, ...props }) => ({
+            ...props,
+            placeholderSelectable: !props.placeholderSelectable
+          })
         }
       ]
     },

--- a/react/Dropdown/Dropdown.js
+++ b/react/Dropdown/Dropdown.js
@@ -65,14 +65,16 @@ export default class Dropdown extends Component {
         label: PropTypes.string
       })
     ),
-    placeholder: PropTypes.string
+    placeholder: PropTypes.string,
+    placeholderSelectable: PropTypes.bool
   };
 
   static defaultProps = {
     id: '',
     className: '',
     placeholder: '',
-    options: []
+    options: [],
+    placeholderSelectable: false
   };
 
   constructor() {
@@ -104,7 +106,7 @@ export default class Dropdown extends Component {
       <select {...allInputProps}>
         <option
           value=""
-          disabled={true}>
+          disabled={!this.props.placeholderSelectable}>
           { placeholder }
         </option>
         {

--- a/react/Dropdown/Dropdown.test.js
+++ b/react/Dropdown/Dropdown.test.js
@@ -100,9 +100,17 @@ describe('Dropdown', () => {
   });
 
   describe('placeholder', () => {
-    it('should render placeholder as first option in list ', () => {
+    it('should render placeholder as first option and disabled in list ', () => {
       render(<Dropdown inputProps={{ value: '' }} options={options} placeholder="test" />);
       expect(placeholderText()).to.equal('test');
+      expect(placeholder.props.disabled).to.equal(true);
+    });
+  });
+
+  describe('placeholder', () => {
+    it('should render placeholder as first option and selectable in list ', () => {
+      render(<Dropdown inputProps={{ value: '' }} options={options} placeholder="test" placeholderSelectable={true} />);
+      expect(placeholder.props.disabled).to.equal(false);
     });
   });
 


### PR DESCRIPTION
Enable Dropdown able to select the original value to clear the selection (which is the placeholder)

EXAMPLE USAGE:

```js
<Dropdown inputProps={{ value: '' }} options={options} placeholder="test" placeholderSelectable={true} />
```
