### PR TITLE
fix(JobStreetHeader): Parameterize JobStreet header's auth status

### DIFF
--- a/jobStreet/Header/Header.demo.js
+++ b/jobStreet/Header/Header.demo.js
@@ -2,6 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import Header from './Header';
+import {
+  AUTHENTICATED,
+  UNAUTHENTICATED,
+  AUTH_PENDING
+} from 'seek-asia-style-guide/react/private/authStatusTypes';
 
 export const makeDummyLinkRendererForPath = path => {
   const DummyLinkRenderer = ({ href, ...props }) => (
@@ -23,7 +28,7 @@ export default {
   title: 'JobStreet Header',
   component: Header,
   initialProps: {
-    authenticationStatus: 'authenticated',
+    authenticationStatus: AUTHENTICATED,
     username: 'Oliver Q.',
     userToken: 'youcannotseemeiamhidden',
     linkRenderer: makeDummyLinkRendererForPath(ROUTE),
@@ -55,14 +60,14 @@ export default {
           label: 'Unauthenticated',
           transformProps: ({ username, ...props }) => ({
             ...props,
-            authenticationStatus: 'unauthenticated'
+            authenticationStatus: UNAUTHENTICATED
           })
         },
         {
           label: 'Pending',
           transformProps: ({ username, ...props }) => ({
             ...props,
-            authenticationStatus: 'pending'
+            authenticationStatus: AUTH_PENDING
           })
         }
       ]

--- a/jobStreet/Header/Header.js
+++ b/jobStreet/Header/Header.js
@@ -9,6 +9,11 @@ import {
   HamburgerIcon,
   Button
 } from 'seek-asia-style-guide/react';
+import {
+  AUTHENTICATED,
+  UNAUTHENTICATED,
+  AUTH_PENDING
+} from 'seek-asia-style-guide/react/private/authStatusTypes';
 import Nav from './components/Nav/Nav';
 import styles from './header.less';
 import links from './links';
@@ -66,7 +71,12 @@ class Header extends Component {
       activeNavLinkTextKey
     } = this.props;
     const { isNavActive } = this.state;
-    const userLinks = links.getUserLinks(username, userToken);
+    let userLinks = {};
+    if (authenticationStatus === AUTHENTICATED) {
+      userLinks = links.getUserLinks(username, userToken);
+    } else if (authenticationStatus === UNAUTHENTICATED) {
+      userLinks = links.getUserLoggedOutLinks();
+    }
     const navLinks = links.getNavLinks(username, userToken);
     const messages = localization[`${language}-${country}`];
 
@@ -91,7 +101,7 @@ class Header extends Component {
               messages={messages}
               activeNavLinkTextKey={activeNavLinkTextKey}
             />
-            {authenticationStatus === 'pending' || (
+            {authenticationStatus === AUTH_PENDING || (
               <Nav key={'userLinks'} links={userLinks} messages={messages} />
             )}
           </div>
@@ -125,9 +135,9 @@ Header.propTypes = {
   username: PropTypes.string,
   userToken: PropTypes.string,
   authenticationStatus: PropTypes.oneOf([
-    'authenticated',
-    'unauthenticated',
-    'pending'
+    AUTHENTICATED,
+    UNAUTHENTICATED,
+    AUTH_PENDING
   ]).isRequired,
   language: PropTypes.string.isRequired,
   country: PropTypes.string.isRequired,

--- a/jobStreet/Header/Header.js
+++ b/jobStreet/Header/Header.js
@@ -71,11 +71,11 @@ class Header extends Component {
       activeNavLinkTextKey
     } = this.props;
     const { isNavActive } = this.state;
-    let userLinks = {};
+    let userLinks = [];
     if (authenticationStatus === AUTHENTICATED) {
       userLinks = links.getUserLinks(username, userToken);
     } else if (authenticationStatus === UNAUTHENTICATED) {
-      userLinks = links.getUserLoggedOutLinks();
+      userLinks = links.getLoggedOutUserLinks();
     }
     const navLinks = links.getNavLinks(username, userToken);
     const messages = localization[`${language}-${country}`];

--- a/jobStreet/Header/Header.test.js
+++ b/jobStreet/Header/Header.test.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Header from './Header';
+import {
+  AUTHENTICATED,
+  UNAUTHENTICATED,
+  AUTH_PENDING
+} from 'seek-asia-style-guide/react/private/authStatusTypes';
 
 describe('JobStreet header component', () => {
   describe('Localisation', () => {
@@ -9,7 +14,7 @@ describe('JobStreet header component', () => {
         <Header
           language="en"
           country="my"
-          authenticationStatus="unathenticated"
+          authenticationStatus={UNAUTHENTICATED}
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -23,7 +28,7 @@ describe('JobStreet header component', () => {
           <Header
             language="en"
             country="my"
-            authenticationStatus="authenticated"
+            authenticationStatus={AUTHENTICATED}
             username="Oliver Q."
           />
         )
@@ -36,7 +41,7 @@ describe('JobStreet header component', () => {
           <Header
             language="en"
             country="my"
-            authenticationStatus="unauthenticated"
+            authenticationStatus={UNAUTHENTICATED}
           />
         )
       ).toMatchSnapshot();
@@ -45,7 +50,7 @@ describe('JobStreet header component', () => {
     it('should render when pending authenticating user', () => {
       expect(
         shallow(
-          <Header language="en" country="my" authenticationStatus="pending" />
+          <Header language="en" country="my" authenticationStatus={AUTH_PENDING} />
         )
       ).toMatchSnapshot();
     });

--- a/jobStreet/Header/components/Nav/nav.less
+++ b/jobStreet/Header/components/Nav/nav.less
@@ -11,8 +11,7 @@
 .item {
   padding: @grid-base 0;
   @media @desktop {
-    padding-top: (@grid-base * 3);
-    padding-bottom: (@grid-base * 3);
+    padding: 0;
     display: inline-block;
     color: @jsNavLinkDesktopColor;
   }
@@ -38,8 +37,7 @@
   text-decoration: none;
   color: @jsNavLinkMobileColor;
   @media @desktop {
-    padding-left: (@grid-base * 2);
-    padding-right: (@grid-base * 2);
+    padding: (@grid-base * 3) (@grid-base * 2);
     color: @jsNavLinkDesktopColor;
     &:hover,
     &:focus {

--- a/jobStreet/Header/links.js
+++ b/jobStreet/Header/links.js
@@ -80,7 +80,7 @@ const getNavLinks = (name, xToken) => {
   return userLoggedOutNavLinks;
 };
 
-const userLoggedOutLinks = [
+const getUserLoggedOutLinks = () => ([
   {
     href: 'header.loginLink',
     title: 'header.loginTitle',
@@ -94,51 +94,50 @@ const userLoggedOutLinks = [
     text: 'header.signUpText',
     childLinks: []
   }
-];
+]);
 
 const getUserLinks = (name, xToken) => {
-  return name && name.length ?
-    [
-      {
-        href: '#',
-        title: name,
-        text: name,
-        preventTranslation: true,
-        childLinks: [
-          {
-            href: 'header.logoutLink',
-            hrefParams: {
-              x: xToken
-            },
-            title: 'header.logoutTitle',
-            text: 'header.logoutText'
+  return [
+    {
+      href: '#',
+      title: name,
+      text: name,
+      preventTranslation: true,
+      childLinks: [
+        {
+          href: 'header.logoutLink',
+          hrefParams: {
+            x: xToken
           },
-          {
-            href: 'header.helpLink',
-            hrefParams: {
-              x: xToken
-            },
-            title: 'header.helpTitle',
-            text: 'header.helpText',
-            hideOnMobile: true,
-            hasDivider: true
+          title: 'header.logoutTitle',
+          text: 'header.logoutText'
+        },
+        {
+          href: 'header.helpLink',
+          hrefParams: {
+            x: xToken
           },
-          {
-            href: 'header.myAccountLink',
-            hrefParams: {
-              x: xToken
-            },
-            title: 'header.myAccountTitle',
-            text: 'header.myAccountText',
-            hideOnMobile: true
-          }
-        ]
-      }
-    ] :
-    userLoggedOutLinks;
+          title: 'header.helpTitle',
+          text: 'header.helpText',
+          hideOnMobile: true,
+          hasDivider: true
+        },
+        {
+          href: 'header.myAccountLink',
+          hrefParams: {
+            x: xToken
+          },
+          title: 'header.myAccountTitle',
+          text: 'header.myAccountText',
+          hideOnMobile: true
+        }
+      ]
+    }
+  ];
 };
 
 export default {
   getNavLinks,
-  getUserLinks
+  getUserLinks,
+  getUserLoggedOutLinks
 };

--- a/jobStreet/Header/links.js
+++ b/jobStreet/Header/links.js
@@ -80,7 +80,7 @@ const getNavLinks = (name, xToken) => {
   return userLoggedOutNavLinks;
 };
 
-const getUserLoggedOutLinks = () => ([
+const getLoggedOutUserLinks = () => ([
   {
     href: 'header.loginLink',
     title: 'header.loginTitle',
@@ -139,5 +139,5 @@ const getUserLinks = (name, xToken) => {
 export default {
   getNavLinks,
   getUserLinks,
-  getUserLoggedOutLinks
+  getLoggedOutUserLinks
 };


### PR DESCRIPTION
Didn't realize that we already parameterized authentication status in the `react/private/authStatusTypes`. Going to change the header to use that for consistency.

##### BREAKING CHANGE:
No breaking change. Original string used in SRP React still works as the string is an exact match from the `authStatusType`.

##### RFC URL: 
N/A

##### MIGRATION GUIDE:
Before:

```js
<Header authenticationStatus="authenticated" ...... />
```

After:
```js
import { AUTHENTICATED } from 'seek-asia-style-guide/react/private/authStatusType';

<JobStreetHeader authenticationStatus={AUTHENTICATED} ...... />
```
