### PR TITLE
fix(JobCard): Long company name breaks flex layout

### DIFF
--- a/react/JobCard/JobCard.js
+++ b/react/JobCard/JobCard.js
@@ -73,7 +73,7 @@ const JobCard = ({ job, keyword = '', jobAdType }) => {
         {title}
       </Section>
       <Section className={styles.bodySection}>
-        <div>
+        <div className={styles.bodyDetailsWrapper}>
           <Text intimate className={styles.company}>
             {job.featuredLabel && (<span className={styles.featuredLabel}>{job.featuredLabel}</span>)}
             {job.classifiedLabel && (<span className={styles.classifiedLabel}>{job.classifiedLabel}</span>)}

--- a/react/JobCard/JobCard.less
+++ b/react/JobCard/JobCard.less
@@ -110,6 +110,12 @@
   justify-content: space-between;
 }
 
+.bodyDetailsWrapper {
+  // Without this, the flex child containing the other text elements
+  // won't narrow past the "implied width" of those text elements.
+  min-width: 0;
+}
+
 .footerSection {
   display: flex;
   justify-content: space-between;

--- a/react/JobCard/__snapshots__/JobCard.test.js.snap
+++ b/react/JobCard/__snapshots__/JobCard.test.js.snap
@@ -19,7 +19,9 @@ exports[`JobCard should render company with bold keyword 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -145,7 +147,9 @@ exports[`JobCard should render job title with bold keyword 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -237,7 +241,9 @@ exports[`JobCard should render jobStreet standout style 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -348,7 +354,9 @@ exports[`JobCard should render jobsDB default style 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -440,7 +448,9 @@ exports[`JobCard should render with Classified in grey label 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -526,7 +536,9 @@ exports[`JobCard should render with company confidential in grey label 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -607,7 +619,9 @@ exports[`JobCard should render with default props 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -688,7 +702,9 @@ exports[`JobCard should render with featured label 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"
@@ -774,7 +790,9 @@ exports[`JobCard should render with selling points props 1`] = `
   <Section
     className="bodySection"
   >
-    <div>
+    <div
+      className="bodyDetailsWrapper"
+    >
       <Text
         baseline={true}
         className="company"


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

Long company forces the entire flex parent element too wide.

BREAKING CHANGE:

n/a
