### PR TITLE
feat(updateLinkInteraction): default job title link pointer-events auto

### DIFF
--- a/react/JobCard/JobCard.less
+++ b/react/JobCard/JobCard.less
@@ -219,6 +219,7 @@
 
 .positionLink {
   text-decoration: none;
+  pointer-events: auto;
 }
 
 .positionLink:visited .positionTitle {


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

This pull request is regarding the following trello card https://trello.com/c/4rLeWd1X/324-job-card-mobile-desktop-interaction

In summary currently the whole job card in SRP is clickable. It was due to the job card been wrap up by <Link> is srp-react. So I plan to use CSS  `pointer-events` the <Link> is only clickable during mobile view, but not desktop. Since the Job Card is the child of <Link> it will affect the Job title link unable to click  in desktop view as well unless i put `pointer-events` in the individual child link.

BREAKING CHANGE:

NO API change here

RFC URL:

{{ URL of associated RFC for API change }}

MIGRATION GUIDE:

Just change of CSS the rest of the calling is still the same.

