### PR TITLE
fix(JobCard): shelflinks should always render

### DIFF
--- a/react/JobCard/JobCard.js
+++ b/react/JobCard/JobCard.js
@@ -121,7 +121,7 @@ export default class JobCard extends React.Component {
             </div>
           )}
         </Section>
-        {job.shelf && shelfSectionOpen && <ShelfSection shelf={job.shelf} LinkComponent={LinkComponent} />}
+        {job.shelf && <ShelfSection shelf={job.shelf} LinkComponent={LinkComponent} showShelfSection={shelfSectionOpen} />}
       </Card>
     );
   }

--- a/react/JobCard/__snapshots__/JobCard.test.js.snap
+++ b/react/JobCard/__snapshots__/JobCard.test.js.snap
@@ -271,6 +271,34 @@ exports[`JobCard should render company with bold keyword 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -452,6 +480,34 @@ exports[`JobCard should render job title with bold keyword 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -618,6 +674,34 @@ exports[`JobCard should render jobStreet standout style 1`] = `
       />
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -765,6 +849,34 @@ exports[`JobCard should render jobsDB default style 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -911,6 +1023,34 @@ exports[`JobCard should render plain company label 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1058,6 +1198,44 @@ exports[`JobCard should render tag links 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+        "tagLinks": Array [
+          Object {
+            "child": "keyword 1",
+            "link": "/jobCard",
+          },
+          Object {
+            "child": "keyword 2",
+            "link": "/jobCard",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1210,6 +1388,34 @@ exports[`JobCard should render with Classified in grey label 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1352,6 +1558,34 @@ exports[`JobCard should render with company confidential in grey label 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1499,6 +1733,34 @@ exports[`JobCard should render with default props 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1651,6 +1913,34 @@ exports[`JobCard should render with featured label 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;
 
@@ -1798,5 +2088,33 @@ exports[`JobCard should render with selling points props 1`] = `
       </div>
     </div>
   </Section>
+  <ShelfSection
+    LinkComponent={[Function]}
+    shelf={
+      Object {
+        "shelfLinks": Array [
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accountant",
+              },
+            ],
+            "label": "Job function",
+          },
+          Object {
+            "child": Array [
+              Object {
+                "link": "/jobCard",
+                "name": "Accounting / Audit / Tax Services",
+              },
+            ],
+            "label": "Industry",
+          },
+        ],
+      }
+    }
+    showShelfSection={false}
+  />
 </Card>
 `;

--- a/react/JobCard/components/ShelfSection/ShelfSection.js
+++ b/react/JobCard/components/ShelfSection/ShelfSection.js
@@ -6,6 +6,7 @@ import Button from '../../../Button/Button';
 import ButtonGroup from '../../../ButtonGroup/ButtonGroup';
 import defaultLink from '../Link/Link';
 import styles from './ShelfSection.less';
+import classnames from 'classnames';
 
 export const ShelfSectionPropTypes = PropTypes.shape({
   shelfLinks: PropTypes.arrayOf(PropTypes.shape({
@@ -28,12 +29,12 @@ export const ShelfSectionPropTypes = PropTypes.shape({
   }))
 });
 
-const ShelfSection = ({ shelf, LinkComponent = defaultLink }) => {
+const ShelfSection = ({ shelf, LinkComponent = defaultLink, showShelfSection = false }) => {
   const { shelfLinks, tagLinks } = shelf;
   if (!shelfLinks && !tagLinks) {
     return null;
   }
-  return (<Section className={styles.root}>
+  return (<Section className={classnames(styles.root, { [styles.showShelfSection]: showShelfSection })}>
     <div className={styles.shelfDivider} />
     {shelfLinks &&
       <Text intimate className={styles.shelfLinksContainer}>
@@ -75,5 +76,6 @@ const ShelfSection = ({ shelf, LinkComponent = defaultLink }) => {
 export default ShelfSection;
 ShelfSection.propTypes = {
   shelf: ShelfSectionPropTypes,
-  LinkComponent: PropTypes.func
+  LinkComponent: PropTypes.func,
+  showShelfSection: PropTypes.bool
 };

--- a/react/JobCard/components/ShelfSection/ShelfSection.less
+++ b/react/JobCard/components/ShelfSection/ShelfSection.less
@@ -5,6 +5,9 @@
   padding-top: @job-card-section-space;
   color: @saGrey2;
   display: none;
+}
+
+.showShelfSection {
   @media @desktop {
     display: block;
   }


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

Shelf's links should always render, but just hide it if user not interest on it. 

BREAKING CHANGE:

{{ Description of breaking API change }}

RFC URL:

{{ URL of associated RFC for API change }}

MIGRATION GUIDE:

Before:

```js
{{ Old code }}
```

After:

```js
{{ New code }}
```

EXAMPLE USAGE:

```js
{{ Code }}
```
