### PR TITLE
feat(disableAsideGap): Adding new props for Aside

### DIFF
--- a/react/AsidedLayout/AsidedLayout.demo.js
+++ b/react/AsidedLayout/AsidedLayout.demo.js
@@ -58,7 +58,7 @@ export default {
       ]
     },
     {
-      label: 'Disable',
+      label: 'Disable Aside',
       type: 'checkbox',
       states: [
         {
@@ -66,6 +66,19 @@ export default {
           transformProps: props => ({
             ...props,
             disableOnMobile: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'Disable Gap',
+      type: 'checkbox',
+      states: [
+        {
+          label: 'Disable Gap In Between',
+          transformProps: props => ({
+            ...props,
+            disableGapInBetween: true
           })
         }
       ]

--- a/react/AsidedLayout/AsidedLayout.js
+++ b/react/AsidedLayout/AsidedLayout.js
@@ -5,21 +5,38 @@ import classnames from 'classnames';
 
 const defaultRenderAside = () => null;
 
-const conditionallyRenderAside = (condition, renderAside, classNameAside, disableOnMobile, size) => (
-  condition ?
+const conditionallyRenderAside = ({
+  condition,
+  renderAside,
+  classNameAside,
+  disableOnMobile,
+  disableGapInBetween,
+  size
+}) =>
+  condition ? (
     <div
       className={classnames({
         [classNameAside]: classNameAside,
         [styles.disableOnMobile]: disableOnMobile,
-        [styles.aside]: true
+        [styles.aside]: true,
+        [styles.gap]: !disableGapInBetween
       })}
       style={{ flexBasis: size }}>
       {renderAside()}
-    </div> :
-    null
-);
+    </div>
+  ) : null;
 
-export default function AsidedLayout({ className, children, renderAside = defaultRenderAside, classNameAside, size, reverse, disableOnMobile, ...restProps }) {
+export default function AsidedLayout({
+  className,
+  children,
+  renderAside = defaultRenderAside,
+  classNameAside,
+  size,
+  reverse,
+  disableOnMobile,
+  disableGapInBetween,
+  ...restProps
+}) {
   return (
     <div
       {...restProps}
@@ -28,11 +45,23 @@ export default function AsidedLayout({ className, children, renderAside = defaul
         [styles.root]: true,
         [styles.reverse]: reverse
       })}>
-      { conditionallyRenderAside(reverse, renderAside, classNameAside, disableOnMobile, size) }
-      <div className={styles.content}>
-        {children}
-      </div>
-      { conditionallyRenderAside(!reverse, renderAside, classNameAside, disableOnMobile, size) }
+      {conditionallyRenderAside({
+        condition: reverse,
+        renderAside,
+        classNameAside,
+        disableOnMobile,
+        disableGapInBetween,
+        size
+      })}
+      <div className={styles.content}>{children}</div>
+      {conditionallyRenderAside({
+        condition: !reverse,
+        renderAside,
+        classNameAside,
+        disableOnMobile,
+        disableGapInBetween,
+        size
+      })}
     </div>
   );
 }
@@ -44,5 +73,16 @@ AsidedLayout.propTypes = {
   classNameAside: PropTypes.string,
   size: PropTypes.string,
   disableOnMobile: PropTypes.bool,
+  disableGapInBetween: PropTypes.bool,
+  reverse: PropTypes.bool
+};
+
+conditionallyRenderAside.propTypes = {
+  condition: PropTypes.bool,
+  renderAside: PropTypes.func,
+  classNameAside: PropTypes.string,
+  size: PropTypes.string,
+  disableOnMobile: PropTypes.bool,
+  disableGapInBetween: PropTypes.bool,
   reverse: PropTypes.bool
 };

--- a/react/AsidedLayout/AsidedLayout.less
+++ b/react/AsidedLayout/AsidedLayout.less
@@ -18,9 +18,14 @@
   }
 }
 
-.aside {
+.gap {
   @media @desktop {
     padding-left: @grid-gutter-width;
+  }
+}
+
+.aside {
+  @media @desktop {
     flex-grow: 0;
     flex-shrink: 0;
   }

--- a/react/ShowMore/ShowMore.js
+++ b/react/ShowMore/ShowMore.js
@@ -10,7 +10,7 @@ export default class ShowMore extends Component {
     showLessHeight: PropTypes.number.isRequired,
     lblShowMore: PropTypes.string,
     lblShowLess: PropTypes.string,
-    disable: PropTypes.boolean
+    disable: PropTypes.bool
   };
 
   static defaultProps = {

--- a/react/ShowMore/ShowMore.test.js
+++ b/react/ShowMore/ShowMore.test.js
@@ -25,7 +25,7 @@ describe('ShowMore:', () => {
     const options = { createNodeMock };
     const wrapper = renderer.create(
       <ShowMore
-        showLessHeight='150'
+        showLessHeight={150}
         lblShowMore='Show more'
         lblShowLess='Show less'>
         {card}


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

In the split mode it do not need the space in between. At the same time doing come clean up in `showmore` component as well

BREAKING CHANGE:

adding a new props

RFC URL:

none

MIGRATION GUIDE:

After:

```
<AsidedLayout
  disableGapInBetween
  renderAside={() => {...}}
  size="30%"
>
```

EXAMPLE USAGE:

```
<AsidedLayout
  disableGapInBetween
  renderAside={() => {...}}
  size="30%"
>
  <Card>
    <Section>
      <Text shouting>
        Main Content
      </Text>
      <Text>
        This card is provided as children.
      </Text>
    </Section>
  </Card>
  <Card>
    <Section>
      <Text shouting>
        Another Card
      </Text>
      <Text>
        Here's another card for good measure.
      </Text>
    </Section>
  </Card>
</AsidedLayout>
```
![capture](https://user-images.githubusercontent.com/20486394/41694749-630622fe-753e-11e8-9860-af46d941e7e1.JPG)
