### PR TITLE
feat(addCompactMode): create a compact mode option and changing badge

### DIFF
--- a/react/ListItem/ListItem.demo.js
+++ b/react/ListItem/ListItem.demo.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ListItem from './ListItem';
-import Badge from '../Badge/Badge';
 import * as sketch from './ListItem.sketch';
 import { HeartIcon, StarIcon } from 'seek-asia-style-guide/react';
 export default {
@@ -66,9 +65,9 @@ export default {
           label: 'with Badge',
           transformProps: props => ({
             ...props,
-            badge: (
-              <Badge label='Badge' color='default' isBold />
-            )
+            badge: {
+              label: 'Badge'
+            }
           })
         }
       ]
@@ -82,6 +81,19 @@ export default {
           transformProps: props => ({
             ...props,
             hasHoverState: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'Compact',
+      type: 'checklist',
+      states: [
+        {
+          label: 'Compact',
+          transformProps: props => ({
+            ...props,
+            compact: true
           })
         }
       ]

--- a/react/ListItem/ListItem.js
+++ b/react/ListItem/ListItem.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import Text from '../Text/Text';
 import Badge from '../Badge/Badge';
 
-const defaultBadgeSetting = {
+const defaultBadgeProps = {
   color: 'default',
   isBold: true
 };
@@ -47,7 +47,7 @@ export default function ListItem({
             className={styles.displayInline}>
             {value}
           </Text>
-          {badge && <span className={styles.listItemBadge}><Badge {... { ...defaultBadgeSetting, ...badge }} /></span>}
+          {badge && <span className={styles.listItemBadge}><Badge {... { ...defaultBadgeProps, ...badge }} /></span>}
         </div>
       </div>
     </div>

--- a/react/ListItem/ListItem.js
+++ b/react/ListItem/ListItem.js
@@ -3,20 +3,51 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Text from '../Text/Text';
+import Badge from '../Badge/Badge';
 
-export default function ListItem({ title, value, icon, badge, isCompact, hasHoverState, noShadow }) {
+const defaultBadgeSetting = {
+  color: 'default',
+  isBold: true
+};
+
+export default function ListItem({
+  title,
+  value,
+  icon,
+  badge,
+  compact,
+  hasHoverState,
+  noShadow
+}) {
   return (
-    <div className={classnames({ [styles.root]: true, [styles.isCompact]: isCompact, [styles.hasHoverState]: hasHoverState, [styles.noShadow]: noShadow })}>
-      {icon && <div className={classnames(styles.listItemIcon)}>{icon}</div>}
-      <div className={classnames(styles.listItemBody)}>
+    <div
+      className={classnames({
+        [styles.root]: true,
+        [styles.hasHoverState]: hasHoverState,
+        [styles.noShadow]: noShadow
+      })}>
+      {icon && <div className={styles.listItemIcon}>{icon}</div>}
+      <div className={styles.listItemBody}>
         {title && (
-          <Text light intimate baseline={false} className={classnames(styles.listItemTitle)}>{title}</Text>
+          <Text
+            light={!compact}
+            regular={compact}
+            intimate
+            baseline={false}
+            className={styles.listItemTitle}>
+            {title}
+          </Text>
         )}
-        <div className={classnames(styles.listItemValue)}>
-          <Text strong loud baseline={false} className={classnames(styles.displayInline)}>{value}</Text>
-          {badge && (
-            <span> <span className={classnames(styles.listItemBadge)}> {badge}</span></span>
-          )}
+        <div className={styles.listItemValue}>
+          <Text
+            strong
+            loud={!compact}
+            waving={compact}
+            baseline={false}
+            className={styles.displayInline}>
+            {value}
+          </Text>
+          {badge && <span className={styles.listItemBadge}><Badge {... { ...defaultBadgeSetting, ...badge }} /></span>}
         </div>
       </div>
     </div>
@@ -26,15 +57,17 @@ export default function ListItem({ title, value, icon, badge, isCompact, hasHove
 ListItem.propTypes = {
   title: PropTypes.string,
   value: PropTypes.string.isRequired,
-  icon: PropTypes.function,
-  badge: PropTypes.function,
-  isCompact: PropTypes.bool,
+  icon: PropTypes.node,
+  badge: PropTypes.object,
+  compact: PropTypes.bool,
   hasHoverState: PropTypes.bool,
   noShadow: PropTypes.bool
 };
 
 ListItem.defaultProps = {
-  isCompact: false,
+  compact: false,
   hasHoverState: false,
-  noShadow: false
+  noShadow: false,
+  badge: null,
+  icon: null
 };

--- a/react/ListItem/ListItem.sketch.js
+++ b/react/ListItem/ListItem.sketch.js
@@ -2,7 +2,6 @@ import React from 'react';
 import mapKeys from 'lodash/mapKeys';
 import ListItem from './ListItem';
 import { IconEducation } from 'seek-asia-style-guide/react';
-// import Badge from '../Badge/Badge';
 
 const badge = {
   label: 'Badge'

--- a/react/ListItem/ListItem.sketch.js
+++ b/react/ListItem/ListItem.sketch.js
@@ -2,7 +2,11 @@ import React from 'react';
 import mapKeys from 'lodash/mapKeys';
 import ListItem from './ListItem';
 import { IconEducation } from 'seek-asia-style-guide/react';
-import Badge from '../Badge/Badge';
+// import Badge from '../Badge/Badge';
+
+const badge = {
+  label: 'Badge'
+};
 
 export const listItem = {
 
@@ -11,8 +15,10 @@ export const listItem = {
   'value, no shadow': <ListItem value='Description' noShadow />,
   'title, value': <ListItem title='Title' value="Description" />,
   'title, value, icon': <ListItem title='Qualification' value='Degree' icon={<IconEducation />} />,
-  'title, value, icon, badge': <ListItem badge={<Badge color="default" isBold label="Badge" />} icon={<IconEducation />} title="Job Posted Date" value="10 May 2018" />,
-  'title, value, icon, badge(diff color)': <ListItem badge={<Badge color="progressing" isBold label="Badge" />} icon={<IconEducation />} title="Job Posted Date" value="10 May 2018" />
+  'title, value, icon, compact': <ListItem title='Qualification' value='Degree' compact icon={<IconEducation />} />,
+  'title, value, icon, badge': <ListItem badge={{ ...badge }} icon={<IconEducation />} title="Job Posted Date" value="10 May 2018" />,
+  'title, value, icon, badge(diff color)': <ListItem badge={{ ...badge, color: 'progressing' }} icon={<IconEducation />} title="Job Posted Date" value="10 May 2018" />,
+  'title, value, icon, hasHoverState, badge(diff color)': <ListItem badge={{ ...badge, color: 'progressing' }} icon={<IconEducation />} title="Job Posted Date" value="10 May 2018" hasHoverState />
 };
 
 // Export text styles as symbols

--- a/react/ListItem/ListItem.test.js
+++ b/react/ListItem/ListItem.test.js
@@ -18,5 +18,20 @@ describe('ListItem:', () => {
     const wrapper = shallow(<ListItem value="testValue" title="testTitle" icon={<IconEducation />} />);
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('should render icon in compact mode', () => {
+    const wrapper = shallow(<ListItem value="testValue" title="testTitle" icon={<IconEducation />} compact />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render icon in hasHoverState mode', () => {
+    const wrapper = shallow(<ListItem value="testValue" title="testTitle" icon={<IconEducation />} hasHoverState />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render icon with badge with hasHoverState and compact mode', () => {
+    const wrapper = shallow(<ListItem value="testValue" title="testTitle" icon={<IconEducation />} hasHoverState compact badge={{ color: 'default', isBold: true, label: 'badge' }} />);
+    expect(wrapper).toMatchSnapshot();
+  });
 });
 

--- a/react/ListItem/__snapshots__/ListItem.test.js.snap
+++ b/react/ListItem/__snapshots__/ListItem.test.js.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListItem: should render icon (compact mode) 1`] = `
-<div
-  className="root"
->
-  <div
-    className="listItemIcon"
-  >
-    <Education icon />
-  </div>
-  <div
-    className="listItemBody"
-  >
-    <Text
-      baseline={false}
-      className="listItemTitle"
-      intimate={true}
-      light={false}
-      regular={true}
-    >
-      testTitle
-    </Text>
-    <div
-      className="listItemValue"
-    >
-      <Text
-        baseline={false}
-        className="displayInline"
-        loud={false}
-        strong={true}
-        waving={true}
-      >
-        testValue
-      </Text>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`ListItem: should render icon 1`] = `
 <div
   className="root"

--- a/react/ListItem/__snapshots__/ListItem.test.js.snap
+++ b/react/ListItem/__snapshots__/ListItem.test.js.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ListItem: should render icon (compact mode) 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="listItemIcon"
+  >
+    <Education icon />
+  </div>
+  <div
+    className="listItemBody"
+  >
+    <Text
+      baseline={false}
+      className="listItemTitle"
+      intimate={true}
+      light={false}
+      regular={true}
+    >
+      testTitle
+    </Text>
+    <div
+      className="listItemValue"
+    >
+      <Text
+        baseline={false}
+        className="displayInline"
+        loud={false}
+        strong={true}
+        waving={true}
+      >
+        testValue
+      </Text>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ListItem: should render icon 1`] = `
 <div
   className="root"
@@ -17,6 +55,7 @@ exports[`ListItem: should render icon 1`] = `
       className="listItemTitle"
       intimate={true}
       light={true}
+      regular={false}
     >
       testTitle
     </Text>
@@ -28,9 +67,133 @@ exports[`ListItem: should render icon 1`] = `
         className="displayInline"
         loud={true}
         strong={true}
+        waving={false}
       >
         testValue
       </Text>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ListItem: should render icon in compact mode 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="listItemIcon"
+  >
+    <Education icon />
+  </div>
+  <div
+    className="listItemBody"
+  >
+    <Text
+      baseline={false}
+      className="listItemTitle"
+      intimate={true}
+      light={false}
+      regular={true}
+    >
+      testTitle
+    </Text>
+    <div
+      className="listItemValue"
+    >
+      <Text
+        baseline={false}
+        className="displayInline"
+        loud={false}
+        strong={true}
+        waving={true}
+      >
+        testValue
+      </Text>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ListItem: should render icon in hasHoverState mode 1`] = `
+<div
+  className="root hasHoverState"
+>
+  <div
+    className="listItemIcon"
+  >
+    <Education icon />
+  </div>
+  <div
+    className="listItemBody"
+  >
+    <Text
+      baseline={false}
+      className="listItemTitle"
+      intimate={true}
+      light={true}
+      regular={false}
+    >
+      testTitle
+    </Text>
+    <div
+      className="listItemValue"
+    >
+      <Text
+        baseline={false}
+        className="displayInline"
+        loud={true}
+        strong={true}
+        waving={false}
+      >
+        testValue
+      </Text>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ListItem: should render icon with badge with hasHoverState and compact mode 1`] = `
+<div
+  className="root hasHoverState"
+>
+  <div
+    className="listItemIcon"
+  >
+    <Education icon />
+  </div>
+  <div
+    className="listItemBody"
+  >
+    <Text
+      baseline={false}
+      className="listItemTitle"
+      intimate={true}
+      light={false}
+      regular={true}
+    >
+      testTitle
+    </Text>
+    <div
+      className="listItemValue"
+    >
+      <Text
+        baseline={false}
+        className="displayInline"
+        loud={false}
+        strong={true}
+        waving={true}
+      >
+        testValue
+      </Text>
+      <span
+        className="listItemBadge"
+      >
+        <Badge
+          color="default"
+          isBold={true}
+          label="badge"
+        />
+      </span>
     </div>
   </div>
 </div>
@@ -48,6 +211,7 @@ exports[`ListItem: should render title value 1`] = `
       className="listItemTitle"
       intimate={true}
       light={true}
+      regular={false}
     >
       testTitle
     </Text>
@@ -59,6 +223,7 @@ exports[`ListItem: should render title value 1`] = `
         className="displayInline"
         loud={true}
         strong={true}
+        waving={false}
       >
         testValue
       </Text>
@@ -82,6 +247,7 @@ exports[`ListItem: should render value 1`] = `
         className="displayInline"
         loud={true}
         strong={true}
+        waving={false}
       >
         testValue
       </Text>


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

The reason why adding a `compact` option is because in job detail page the value of the `ListItem` is almost same as the job title and things do look a bit weird as below:

![reason change list item](https://user-images.githubusercontent.com/20486394/41894229-d7243084-7950-11e8-9a7e-4e219380a36f.JPG)

Beside I also changing the `badge` props in this component from function to object. The reason is because it call `badge`, will be make more sense to just pass in the `badge` attribute value than passing the whole component.

BREAKING CHANGE:

changing `badge` from function to object

RFC URL:

none

MIGRATION GUIDE:

Before:

```js
<ListItem
  badge={<Badge color="default" isBold label="Badge"/>}
  value="Description"
/>
```

After:

```js
<ListItem
  badge={{ value:'badge' }}
  value="Description"
/>
```

EXAMPLE USAGE:

```js
<ListItem
  badge={{ value:'badge' }}
  value="Description"
  compact
/>
```
SCREEN SHOT:

![list item](https://user-images.githubusercontent.com/20486394/41894755-93d082ea-7952-11e8-9dea-4954ddb22659.gif)
