### PR TITLE
Feat/split view height

### DIFF
--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -2,21 +2,18 @@
 
 exports[`Autosuggest should render with compact prop 1`] = `
 <div>
-  <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root compact"
     >
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
+        aria-expanded="false"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
+        role="combobox"
         type="text"
         value=""
       />
@@ -40,7 +37,6 @@ exports[`Autosuggest should render with compact prop 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
-      role="listbox"
     />
   </div>
   <div
@@ -51,12 +47,7 @@ exports[`Autosuggest should render with compact prop 1`] = `
 
 exports[`Autosuggest should render with label 1`] = `
 <div>
-  <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root"
     >
@@ -81,11 +72,13 @@ exports[`Autosuggest should render with label 1`] = `
       </label>
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
+        aria-expanded="false"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
+        role="combobox"
         type="text"
         value=""
       />
@@ -109,7 +102,6 @@ exports[`Autosuggest should render with label 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel"
       id="react-autowhatever-1"
-      role="listbox"
     />
   </div>
   <div
@@ -120,12 +112,7 @@ exports[`Autosuggest should render with label 1`] = `
 
 exports[`Autosuggest should render with mobile backdrop 1`] = `
 <div>
-  <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root"
     >
@@ -150,11 +137,13 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
       </label>
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
+        aria-expanded="false"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
+        role="combobox"
         type="text"
         value=""
       />
@@ -178,7 +167,6 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel"
       id="react-autowhatever-1"
-      role="listbox"
     />
   </div>
   <div
@@ -189,12 +177,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
 
 exports[`Autosuggest should render with mobile full width 1`] = `
 <div>
-  <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root"
     >
@@ -219,11 +202,13 @@ exports[`Autosuggest should render with mobile full width 1`] = `
       </label>
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
+        aria-expanded="false"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
+        role="combobox"
         type="text"
         value=""
       />
@@ -247,7 +232,6 @@ exports[`Autosuggest should render with mobile full width 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel suggestionsContainer_fullWidth"
       id="react-autowhatever-1"
-      role="listbox"
     />
   </div>
   <div
@@ -258,21 +242,18 @@ exports[`Autosuggest should render with mobile full width 1`] = `
 
 exports[`Autosuggest should render with simple props 1`] = `
 <div>
-  <div
-    aria-expanded="false"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root"
     >
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
+        aria-expanded="false"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
+        role="combobox"
         type="text"
         value=""
       />
@@ -296,7 +277,6 @@ exports[`Autosuggest should render with simple props 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
-      role="listbox"
     />
   </div>
   <div
@@ -307,21 +287,18 @@ exports[`Autosuggest should render with simple props 1`] = `
 
 exports[`Autosuggest should render with suggestions 1`] = `
 <div>
-  <div
-    aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-owns="react-autowhatever-1"
-    role="combobox"
-  >
+  <div>
     <div
       class="root"
     >
       <input
         aria-autocomplete="list"
-        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
+        aria-expanded="true"
+        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
+        role="combobox"
         type="text"
         value=""
       />
@@ -345,13 +322,11 @@ exports[`Autosuggest should render with suggestions 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
-      role="listbox"
     >
       <ul
         role="listbox"
       >
         <li
-          aria-selected="false"
           data-suggestion-index="0"
           id="react-autowhatever-1--item-0"
           role="option"
@@ -363,7 +338,6 @@ exports[`Autosuggest should render with suggestions 1`] = `
           </span>
         </li>
         <li
-          aria-selected="false"
           data-suggestion-index="1"
           id="react-autowhatever-1--item-1"
           role="option"

--- a/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
+++ b/react/Autosuggest/__snapshots__/Autosuggest.test.js.snap
@@ -2,18 +2,21 @@
 
 exports[`Autosuggest should render with compact prop 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root compact"
     >
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
-        aria-expanded="false"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
-        role="combobox"
         type="text"
         value=""
       />
@@ -37,6 +40,7 @@ exports[`Autosuggest should render with compact prop 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
+      role="listbox"
     />
   </div>
   <div
@@ -47,7 +51,12 @@ exports[`Autosuggest should render with compact prop 1`] = `
 
 exports[`Autosuggest should render with label 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root"
     >
@@ -72,13 +81,11 @@ exports[`Autosuggest should render with label 1`] = `
       </label>
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
-        aria-expanded="false"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
-        role="combobox"
         type="text"
         value=""
       />
@@ -102,6 +109,7 @@ exports[`Autosuggest should render with label 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel"
       id="react-autowhatever-1"
+      role="listbox"
     />
   </div>
   <div
@@ -112,7 +120,12 @@ exports[`Autosuggest should render with label 1`] = `
 
 exports[`Autosuggest should render with mobile backdrop 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root"
     >
@@ -137,13 +150,11 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
       </label>
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
-        aria-expanded="false"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
-        role="combobox"
         type="text"
         value=""
       />
@@ -167,6 +178,7 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel"
       id="react-autowhatever-1"
+      role="listbox"
     />
   </div>
   <div
@@ -177,7 +189,12 @@ exports[`Autosuggest should render with mobile backdrop 1`] = `
 
 exports[`Autosuggest should render with mobile full width 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root"
     >
@@ -202,13 +219,11 @@ exports[`Autosuggest should render with mobile full width 1`] = `
       </label>
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="Foo-message"
-        aria-expanded="false"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
         id="Foo"
-        role="combobox"
         type="text"
         value=""
       />
@@ -232,6 +247,7 @@ exports[`Autosuggest should render with mobile full width 1`] = `
     <div
       class="suggestionsContainer suggestionsContainer_withLabel suggestionsContainer_fullWidth"
       id="react-autowhatever-1"
+      role="listbox"
     />
   </div>
   <div
@@ -242,18 +258,21 @@ exports[`Autosuggest should render with mobile full width 1`] = `
 
 exports[`Autosuggest should render with simple props 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="false"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root"
     >
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
-        aria-expanded="false"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
-        role="combobox"
         type="text"
         value=""
       />
@@ -277,6 +296,7 @@ exports[`Autosuggest should render with simple props 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
+      role="listbox"
     />
   </div>
   <div
@@ -287,18 +307,21 @@ exports[`Autosuggest should render with simple props 1`] = `
 
 exports[`Autosuggest should render with suggestions 1`] = `
 <div>
-  <div>
+  <div
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-owns="react-autowhatever-1"
+    role="combobox"
+  >
     <div
       class="root"
     >
       <input
         aria-autocomplete="list"
+        aria-controls="react-autowhatever-1"
         aria-describedby="undefined-message"
-        aria-expanded="true"
-        aria-owns="react-autowhatever-1"
         autocomplete="off"
         class="input"
-        role="combobox"
         type="text"
         value=""
       />
@@ -322,11 +345,13 @@ exports[`Autosuggest should render with suggestions 1`] = `
     <div
       class="suggestionsContainer"
       id="react-autowhatever-1"
+      role="listbox"
     >
       <ul
         role="listbox"
       >
         <li
+          aria-selected="false"
           data-suggestion-index="0"
           id="react-autowhatever-1--item-0"
           role="option"
@@ -338,6 +363,7 @@ exports[`Autosuggest should render with suggestions 1`] = `
           </span>
         </li>
         <li
+          aria-selected="false"
           data-suggestion-index="1"
           id="react-autowhatever-1--item-1"
           role="option"

--- a/react/SplitView/SplitView.demo.js
+++ b/react/SplitView/SplitView.demo.js
@@ -2,13 +2,11 @@ import React from 'react';
 import SplitView from './SplitView';
 import { Card, Section, Text } from 'seek-asia-style-guide/react';
 
-export default {
-  route: '/split-view',
-  title: 'Split View',
-  component: SplitView,
-  initialProps: {
-    children: [
-      <Card key="1">
+const leftCards = number => {
+  const cards = [];
+  for (let i = 0; i < number; i++) {
+    cards.push(
+      <Card>
         <Section>
           <Text shouting>Left Content</Text>
           <Text>
@@ -17,8 +15,17 @@ export default {
             and large screen.
           </Text>
         </Section>
-      </Card>,
-      <Card key="2">
+      </Card>
+    );
+  }
+  return <div key="leftCards">{cards}</div>;
+};
+
+const rightCards = number => {
+  const cards = [];
+  for (let i = 0; i < number; i++) {
+    cards.push(
+      <Card>
         <Section>
           <Text shouting>Right Content</Text>
           <Text>
@@ -27,7 +34,44 @@ export default {
           </Text>
         </Section>
       </Card>
-    ]
+    );
+  }
+  return <div key="rightCards">{cards}</div>;
+};
+
+export default {
+  route: '/split-view',
+  title: 'Split View',
+  component: SplitView,
+  initialProps: {
+    children: [leftCards(3), rightCards(5)]
   },
-  options: []
+  options: [
+    {
+      label: 'Height',
+      type: 'radio',
+      states: [
+        {
+          label: 'No height',
+          transformProps: props => ({
+            ...props
+          })
+        },
+        {
+          label: '300px',
+          transformProps: props => ({
+            ...props,
+            height: 300
+          })
+        },
+        {
+          label: '500px',
+          transformProps: props => ({
+            ...props,
+            height: 500
+          })
+        }
+      ]
+    }
+  ]
 };

--- a/react/SplitView/SplitView.demo.js
+++ b/react/SplitView/SplitView.demo.js
@@ -44,7 +44,7 @@ export default {
   title: 'Split View',
   component: SplitView,
   initialProps: {
-    children: [leftCards(3), rightCards(5)]
+    children: [leftCards(4), rightCards(6)]
   },
   options: [
     {

--- a/react/SplitView/SplitView.js
+++ b/react/SplitView/SplitView.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styles from './SplitView.less';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 export default function SplitView({ children, height }) {
   const heightStyle = height ? { height } : null;
@@ -9,7 +8,7 @@ export default function SplitView({ children, height }) {
     <div className={styles.root}>
       {children &&
         children.length > 0 && (
-        <div className={styles.leftChild} style={{height}}>
+        <div className={styles.leftChild} style={{ height }}>
           {children[0]}
         </div>
       )}

--- a/react/SplitView/SplitView.js
+++ b/react/SplitView/SplitView.js
@@ -23,5 +23,5 @@ export default function SplitView({ children, height }) {
 
 SplitView.propTypes = {
   children: PropTypes.node.isRequired,
-  height: PropTypes.int
+  height: PropTypes.number
 };

--- a/react/SplitView/SplitView.js
+++ b/react/SplitView/SplitView.js
@@ -3,7 +3,6 @@ import styles from './SplitView.less';
 import PropTypes from 'prop-types';
 
 export default function SplitView({ children, height }) {
-  const heightStyle = height ? { height } : null;
   return (
     <div className={styles.root}>
       {children &&
@@ -14,7 +13,7 @@ export default function SplitView({ children, height }) {
       )}
       {children &&
         children.length > 1 && (
-        <div className={styles.rightChild} style={heightStyle}>
+        <div className={styles.rightChild} style={{ height }}>
           {children.slice(1)}
         </div>
       )}

--- a/react/SplitView/SplitView.js
+++ b/react/SplitView/SplitView.js
@@ -1,22 +1,29 @@
 import React from 'react';
 import styles from './SplitView.less';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 
-export default function SplitView({ children }) {
+export default function SplitView({ children, height }) {
+  const heightStyle = height ? { height } : null;
   return (
     <div className={styles.root}>
       {children &&
         children.length > 0 && (
-        <div className={styles.leftChild}>{children[0]}</div>
+        <div className={styles.leftChild} style={{height}}>
+          {children[0]}
+        </div>
       )}
       {children &&
         children.length > 1 && (
-        <div className={styles.rightChild}>{children.slice(1)}</div>
+        <div className={styles.rightChild} style={heightStyle}>
+          {children.slice(1)}
+        </div>
       )}
     </div>
   );
 }
 
 SplitView.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  height: PropTypes.int
 };

--- a/react/SplitView/SplitView.less
+++ b/react/SplitView/SplitView.less
@@ -12,6 +12,7 @@
   @media @new-desktop-widescreen {
     max-width: @gutter-width * 22;
   }
+  overflow-y: auto;
 }
 
 .rightChild {
@@ -20,4 +21,5 @@
   @media @new-tablet, @new-desktop, @new-desktop-widescreen {
     display: inherit;
   }
+  overflow-y: auto;
 }

--- a/react/SplitView/SplitView.test.js
+++ b/react/SplitView/SplitView.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SplitView from './SplitView';
+
+const renderSplitView = props =>
+  shallow(
+    <SplitView {...props}>
+      <div> Child 1</div>
+      <div> Child 2</div>
+    </SplitView>
+  );
+
+describe('Split View:', () => {
+  it('should render with default props', () => {
+    expect(renderSplitView()).toMatchSnapshot();
+  });
+
+  it('should render with height prop', () => {
+    expect(renderSplitView({ height: 200 })).toMatchSnapshot();
+  });
+
+});

--- a/react/SplitView/SplitView.test.js
+++ b/react/SplitView/SplitView.test.js
@@ -19,5 +19,4 @@ describe('Split View:', () => {
   it('should render with height prop', () => {
     expect(renderSplitView({ height: 200 })).toMatchSnapshot();
   });
-
 });

--- a/react/SplitView/__snapshots__/SplitView.test.js.snap
+++ b/react/SplitView/__snapshots__/SplitView.test.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Split View: should render with default props 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="leftChild"
+    style={
+      Object {
+        "height": undefined,
+      }
+    }
+  >
+    <div>
+       Child 1
+    </div>
+  </div>
+  <div
+    className="rightChild"
+    style={null}
+  >
+    <div>
+       Child 2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Split View: should render with height prop 1`] = `
+<div
+  className="root"
+>
+  <div
+    className="leftChild"
+    style={
+      Object {
+        "height": 200,
+      }
+    }
+  >
+    <div>
+       Child 1
+    </div>
+  </div>
+  <div
+    className="rightChild"
+    style={
+      Object {
+        "height": 200,
+      }
+    }
+  >
+    <div>
+       Child 2
+    </div>
+  </div>
+</div>
+`;

--- a/react/SplitView/__snapshots__/SplitView.test.js.snap
+++ b/react/SplitView/__snapshots__/SplitView.test.js.snap
@@ -18,7 +18,11 @@ exports[`Split View: should render with default props 1`] = `
   </div>
   <div
     className="rightChild"
-    style={null}
+    style={
+      Object {
+        "height": undefined,
+      }
+    }
   >
     <div>
        Child 2


### PR DESCRIPTION
Adding height prop for split view. This is needed for items to scroll independently. Proper height will be calculated on SRP and provided to this component as a prop.

RFC URL:

https://trello.com/c/i1uiip6x/101-split-mode-scrolling