### PR TITLE
Feature/show more click event

### DIFF
--- a/react/ShowMore/ShowMore.demo.js
+++ b/react/ShowMore/ShowMore.demo.js
@@ -56,27 +56,21 @@ export default {
           label: '150px height',
           transformProps: props => ({
             ...props,
-            showLessHeight: 150,
-            lblShowMore: 'Show more',
-            lblShowLess: 'Show less'
+            showLessHeight: 150
           })
         },
         {
           label: '300px Height',
           transformProps: props => ({
             ...props,
-            showLessHeight: 300,
-            lblShowMore: 'Show more',
-            lblShowLess: 'Show less'
+            showLessHeight: 300
           })
         },
         {
           label: '700px Height',
           transformProps: props => ({
             ...props,
-            showLessHeight: 700,
-            lblShowMore: 'Show more',
-            lblShowLess: 'Show less'
+            showLessHeight: 700
           })
         }
       ]
@@ -89,9 +83,22 @@ export default {
           label: 'disable',
           transformProps: props => ({
             ...props,
-            disable: true,
-            lblShowMore: 'Show more',
-            lblShowLess: 'Show less'
+            disable: true
+          })
+        }
+      ]
+    },
+    {
+      label: 'onClickEvent',
+      type: 'checklist',
+      states: [
+        {
+          label: 'onClickEvent',
+          transformProps: props => ({
+            ...props,
+            onClickEvent: () => {
+              alert('hi'); // eslint-disable-line no-alert
+            }
           })
         }
       ]

--- a/react/ShowMore/ShowMore.demo.js
+++ b/react/ShowMore/ShowMore.demo.js
@@ -89,14 +89,14 @@ export default {
       ]
     },
     {
-      label: 'onClickEvent',
+      label: 'onPanelOpen',
       type: 'checklist',
       states: [
         {
-          label: 'onClickEvent',
+          label: 'onPanelOpen',
           transformProps: props => ({
             ...props,
-            onClickEvent: () => {
+            onPanelOpen: () => {
               alert('hi'); // eslint-disable-line no-alert
             }
           })

--- a/react/ShowMore/ShowMore.js
+++ b/react/ShowMore/ShowMore.js
@@ -10,7 +10,8 @@ export default class ShowMore extends Component {
     showLessHeight: PropTypes.number.isRequired,
     lblShowMore: PropTypes.string,
     lblShowLess: PropTypes.string,
-    disable: PropTypes.bool
+    disable: PropTypes.bool,
+    onClickEvent: PropTypes.func
   };
 
   static defaultProps = {
@@ -46,10 +47,12 @@ export default class ShowMore extends Component {
   }
 
   handleClick(e) {
+    const { onClickEvent = () => {} } = this.props;
     e.preventDefault();
     this.setState({
       isPanelOpened: !this.state.isPanelOpened
     });
+    onClickEvent();
   }
 
   render() {

--- a/react/ShowMore/ShowMore.js
+++ b/react/ShowMore/ShowMore.js
@@ -11,7 +11,7 @@ export default class ShowMore extends Component {
     lblShowMore: PropTypes.string,
     lblShowLess: PropTypes.string,
     disable: PropTypes.bool,
-    onClickEvent: PropTypes.func
+    onPanelOpen: PropTypes.func
   };
 
   static defaultProps = {
@@ -47,12 +47,16 @@ export default class ShowMore extends Component {
   }
 
   handleClick(e) {
-    const { onClickEvent = () => {} } = this.props;
+    const { onPanelOpen = () => {} } = this.props;
     e.preventDefault();
+
+    if (!this.state.isPanelOpened) {
+      onPanelOpen();
+    }
+
     this.setState({
       isPanelOpened: !this.state.isPanelOpened
     });
-    onClickEvent();
   }
 
   render() {


### PR DESCRIPTION
** Please provide as much detail as possible, but feel free to remove irrelevant sections **

Need to add omniture tracking when `Show more` link is been trigger.

BREAKING CHANGE:

adding new props name onPanelOpen, prop type will be function and will be trigger when the `Show more` link is been click

RFC URL:

none

MIGRATION GUIDE:

Before:

```none
```

After:

```none
```

EXAMPLE USAGE:

```
<ShowMore
  onPanelOpen={() => {...}}
  showLessHeight={100}
>
<div>more</div>
</ShowMore>
```
