### PR TITLE
fix(Dropdown): Standardize with normal text input font-size (16px)

### DIFF
--- a/react/Dropdown/Dropdown.less
+++ b/react/Dropdown/Dropdown.less
@@ -12,7 +12,7 @@
 }
 
 .dropdown {
-  .touchableText();
+  .touchableText(@conversational-type-scale);
   width: 100%;
   display: block;
   padding: 0 @chevronWidth 0 @field-gutter-width;


### PR DESCRIPTION
REASON FOR CHANGE:
Reduce font-size of Dropdown from default 18px to 16px, standardize with normal text input font-size.