### PR TITLE
fix(Header): Remove invitation and account link

### DIFF
--- a/jobStreet/Header/Header.js
+++ b/jobStreet/Header/Header.js
@@ -18,8 +18,9 @@ const getJobStreetProps = ({ country, language }) => {
   ];
 
   const userAccMenuItems = [
-    { ... _get(headerMessage, 'account'), ItemIcon: ProfileIcon, EnableIcon: true },
-    { ... _get(headerMessage, 'invitation'), ItemIcon: JobInvitationIcon, EnableIcon: true },
+    // Remove for short-term solution since FB user are having issue with this two link, Bricks team are fixing
+    // { ... _get(headerMessage, 'account'), ItemIcon: ProfileIcon, EnableIcon: true },
+    // { ... _get(headerMessage, 'invitation'), ItemIcon: JobInvitationIcon, EnableIcon: true },
     { ... _get(headerMessage, 'logout'), ItemIcon: JobFunctionIcon, EnableIcon: false }
   ];
 

--- a/jobStreet/Header/Header.js
+++ b/jobStreet/Header/Header.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styles from './Header.less';
 import { Header as GlobalHeader } from 'seek-asia-style-guide/react';
 import Logo from '../Logo/Logo';
-import { PortalIcon, CompanyIcon, EducationIcon, ProfileIcon, JobInvitationIcon, JobFunctionIcon } from 'seek-asia-style-guide/react';
+import { PortalIcon, CompanyIcon, EducationIcon, /* ProfileIcon, JobInvitationIcon, */ JobFunctionIcon } from 'seek-asia-style-guide/react';
 import { getLocalization, locales } from '../localization';
 import _get from 'lodash/get';
 

--- a/jobStreet/Header/__snapshots__/Header.test.js.snap
+++ b/jobStreet/Header/__snapshots__/Header.test.js.snap
@@ -175,18 +175,6 @@ exports[`JobStreet Header passes through optional props 1`] = `
   userAccMenuItems={
     Array [
       Object {
-        "EnableIcon": true,
-        "ItemIcon": [Function],
-        "title": "Account",
-        "url": "https://myjobstreet.jobstreet.com.my/registration/update-account.php",
-      },
-      Object {
-        "EnableIcon": true,
-        "ItemIcon": [Function],
-        "title": "Invitation",
-        "url": "https://myjobstreet.jobstreet.com.my/application/interview-request.php?view=latest",
-      },
-      Object {
         "EnableIcon": false,
         "ItemIcon": [Function],
         "title": "Logout",
@@ -366,18 +354,6 @@ exports[`JobStreet Header renders with default props 1`] = `
   onMenuOpen={[Function]}
   userAccMenuItems={
     Array [
-      Object {
-        "EnableIcon": true,
-        "ItemIcon": [Function],
-        "title": "Account",
-        "url": "https://myjobstreet.jobstreet.com.my/registration/update-account.php",
-      },
-      Object {
-        "EnableIcon": true,
-        "ItemIcon": [Function],
-        "title": "Invitation",
-        "url": "https://myjobstreet.jobstreet.com.my/application/interview-request.php?view=latest",
-      },
       Object {
         "EnableIcon": false,
         "ItemIcon": [Function],


### PR DESCRIPTION
Jobstreet SG having issue when user logged in from FB the `Account` & `Invitation` link is not working. Short term solution is remove them while Bricks team fixing